### PR TITLE
Avoid 'Symbol not found: _sprintf_s' on 'from PIL import _webp'

### DIFF
--- a/_webp.c
+++ b/_webp.c
@@ -45,9 +45,9 @@ PyObject* HandleMuxError(WebPMuxError err, char* chunk) {
 
     // Create the error message
     if (chunk == NULL) {
-        message_len = sprintf_s(message, 100, "could not assemble chunks: %s", kErrorMessages[-err]);
+        message_len = sprintf(message, "could not assemble chunks: %s", kErrorMessages[-err]);
     } else {
-        message_len = sprintf_s(message, 100, "could not set %.4s chunk: %s", chunk, kErrorMessages[-err]);
+        message_len = sprintf(message, "could not set %.4s chunk: %s", chunk, kErrorMessages[-err]);
     }
     if (message_len < 0) {
         PyErr_SetString(PyExc_RuntimeError, "failed to construct error message");


### PR DESCRIPTION
Fixes this problem (using this branch on macOS Sierra):

```
$ python
Python 2.7.13 (default, Dec 18 2016, 07:03:39)
[GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from PIL import _webp
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: dlopen(PIL/_webp.so, 2): Symbol not found: _sprintf_s
  Referenced from: PIL/_webp.so
  Expected in: flat namespace
 in PIL/_webp.so
>>> 
```

After replacing `_sprintf_s` with `sprintf`:
```
$ python
Python 2.7.13 (default, Dec 18 2016, 07:03:39)
[GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from PIL import _webp
>>> 
```

---

Without the fix, setup.py said "WEBP support available":
https://travis-ci.org/python-pillow/Pillow/jobs/281460879#L2635

But moments later selftest.py said "WEBP support not installed":
https://travis-ci.org/python-pillow/Pillow/jobs/281460879#L2654

That's because setup.py looks for library headers and things, but selftest.py uses Pillow's `features.check("webp")`, which is essentially doing the same `try: from PIL import _webp...` and fails. Let's use `features` for consistency.